### PR TITLE
Added extended option for body-parser urlencoded()

### DIFF
--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -8,7 +8,7 @@ var query = Npm.require('connect-query');
 
 JsonRoutes = {};
 
-WebApp.connectHandlers.use(bodyParser.urlencoded({limit: '50mb'})); //Override default request size
+WebApp.connectHandlers.use(bodyParser.urlencoded({limit: '50mb', extended: false})); //Override default request size
 WebApp.connectHandlers.use(bodyParser.json({limit: '50mb'})); //Override default request size
 WebApp.connectHandlers.use(query());
 


### PR DESCRIPTION
Resolved error: 'body-parser deprecated undefined extended: provide extended option at packages/simple_json-routes.js:33:39' by passing through the required extended option. The extended option allows to choose between parsing the URL-encoded data with the querystring library (when false) or the qs library (when true).