### PR TITLE
Migrate `json-routes` to Meteor 3.0

### DIFF
--- a/packages/json-routes/.npm/package/npm-shrinkwrap.json
+++ b/packages/json-routes/.npm/package/npm-shrinkwrap.json
@@ -1,77 +1,167 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 4,
   "dependencies": {
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
     "body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw=="
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA=="
     },
     "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
-    "connect": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
-      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="
+    "call-bind": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ=="
     },
-    "connect-query": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/connect-query/-/connect-query-1.0.0.tgz",
-      "integrity": "sha1-3kT1dyCdokBNH8BGktGkEY5YIRk=",
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-        }
-      }
-    },
-    "connect-route": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/connect-route/-/connect-route-0.1.5.tgz",
-      "integrity": "sha1-48IYMZ0uiKiprgsOD+Cacpw5dEo="
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
     },
+    "define-data-property": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ=="
+    },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "dependencies": {
+        "body-parser": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw=="
+        },
+        "raw-body": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig=="
+        }
+      }
+    },
+    "express-query-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/express-query-parser/-/express-query-parser-1.3.3.tgz",
+      "integrity": "sha512-sL4G5D3e1WVNQv28KmwWVpBPtUaqdhZV62nPNe409terbS4RPvTHCHqEKgYH4uyxeBQWcK0kYJ2KABxOt0GbDA=="
     },
     "finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg=="
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA=="
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA=="
+    },
+    "has-property-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg=="
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA=="
     },
     "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -79,69 +169,146 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g=="
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "object-inspect": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
     },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="
     },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="
+    },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g=="
+    },
+    "set-function-length": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w=="
+    },
     "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw=="
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -151,12 +318,17 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     }
   }
 }

--- a/packages/json-routes/.npm/package/npm-shrinkwrap.json
+++ b/packages/json-routes/.npm/package/npm-shrinkwrap.json
@@ -26,6 +26,18 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ=="
     },
+    "connect-query": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/connect-query/-/connect-query-1.0.0.tgz",
+      "integrity": "sha512-D4LX56+26kaEeaJPjmeNsKRuePqDEaQhVU4ThQSrwEoGDivQlQiNZ32sCsbQ0++v6kxeownTYKUJm84YaHuePg==",
+      "dependencies": {
+        "qs": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.1.tgz",
+          "integrity": "sha512-LQy1Q1fcva/UsnP/6Iaa4lVeM49WiOitu2T4hZCyA/elLKu37L99qcBJk4VCCk+rdLvnMzfKyiN3SZTqdAZGSQ=="
+        }
+      }
+    },
     "content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -102,11 +114,6 @@
           "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig=="
         }
       }
-    },
-    "express-query-parser": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/express-query-parser/-/express-query-parser-1.3.3.tgz",
-      "integrity": "sha512-sL4G5D3e1WVNQv28KmwWVpBPtUaqdhZV62nPNe409terbS4RPvTHCHqEKgYH4uyxeBQWcK0kYJ2KABxOt0GbDA=="
     },
     "finalhandler": {
       "version": "1.2.0",

--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -1,10 +1,30 @@
 # Compatibility
 
-**Compatible with Meteor 2.4**
+**Compatible with Meteor 3.0**
 
 This repository provides versions for the package [simple:authenticate-user-by-token](https://github.com/meteor-compat/meteor-rest/tree/devel/packages/authenticate-user-by-token) that are compatible with latest Meteor. This is necessary because the author is not maintaining package anymore.
 
+## Breaking changes
+- v3.0.0 
+
+  - In the previous versions, `connect-route` returned `req.route` as [a string](https://github.com/baryshev/connect-route/blob/master/lib/connect-route.js) representing the path.
+  
+    After the migration to `express`, we use `express.Router()` instead, which returns `req.route` as an object.
+
+    So, in your `handler(request, response, next)` (see [API](#api) below), the request path can be found at `req.route.path`.
+
+    More info on `express.Router` can be found in the [official documentation](https://expressjs.com/en/api.html#router).
+
+**TODO**
+- Add other breaking changes as we identify them.
+- Update `README` in regard to middlewares.
+
 ## Changes
+- v3.0.0
+  - New `webapp` APIs available in [Meteor 3.0](https://github.com/meteor/meteor/blob/release-3.0/docs/generators/changelog/versions/3.0.md).
+  - Npm dependencies updated to reflect migration from `connect` to `express`.
+  - `Fibers` usage was removed and replaced with `async`/`await`.
+  - Deprecated `http` package replaced with `fetch` in tests.
 - v2.3.1
   - Fixes "body-parser deprecated undefined extended"
 - v2.3.0

--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -16,6 +16,7 @@ This repository provides versions for the package [simple:authenticate-user-by-t
     More info on `express.Router` can be found in the [official documentation](https://expressjs.com/en/api.html#router).
 
 **TODO**
+- Find a way to warn the user about the `req.route` breaking change.
 - Add other breaking changes as we identify them.
 - Update `README` in regard to middlewares.
 

--- a/packages/json-routes/json-routes-tests.js
+++ b/packages/json-routes/json-routes-tests.js
@@ -11,6 +11,10 @@ if (Meteor.isServer) {
   JsonRoutes.add('get', 'case-insensitive-method-3', function (req, res) {
     JsonRoutes.sendResult(res, {data: true});
   });
+
+  JsonRoutes.add('get', 'query-parameters-method-1', function (req, res) {
+    JsonRoutes.sendResult(res, {data: req.query});
+  });
 } else {
   // Meteor.isClient
   Tinytest.addAsync('JSON Routes - support case-insensitive HTTP method types - Method 1', async function (test) {
@@ -43,4 +47,13 @@ if (Meteor.isServer) {
     }
   });
 
+  Tinytest.addAsync('JSON Routes - test query parameters parsing - Method 1', async function (test) {
+    try {
+      const response = await fetch('/query-parameters-method-1?foo=bar');
+      const data = await response.json();
+      test.equal(data.foo, 'bar');
+    } catch (err) {
+      test.fail('Fetch failed: ' + err);
+    }
+  });
 }

--- a/packages/json-routes/json-routes-tests.js
+++ b/packages/json-routes/json-routes-tests.js
@@ -13,26 +13,34 @@ if (Meteor.isServer) {
   });
 } else {
   // Meteor.isClient
-  testAsyncMulti('JSON Routes - support case-insensitive HTTP method types', [
-    function (test, expect) {
-      HTTP.get('/case-insensitive-method-1', expect(function (err, res) {
-        test.equal(err, null);
-        test.equal(res.data, true);
-      }));
-    },
+  Tinytest.addAsync('JSON Routes - support case-insensitive HTTP method types - Method 1', async function (test) {
+    try {
+      const response = await fetch('/case-insensitive-method-1');
+      const data = await response.json();
+      test.equal(data, true);
+    } catch (err) {
+      test.fail('Fetch failed: ' + err);
+    }
+  });
 
-    function (test, expect) {
-      HTTP.get('/case-insensitive-method-2', expect(function (err, res) {
-        test.equal(err, null);
-        test.equal(res.data, true);
-      }));
-    },
+  Tinytest.addAsync('JSON Routes - support case-insensitive HTTP method types - Method 2', async function (test) {
+    try {
+      const response = await fetch('/case-insensitive-method-2');
+      const data = await response.json();
+      test.equal(data, true);
+    } catch (err) {
+      test.fail('Fetch failed: ' + err);
+    }
+  });
 
-    function (test, expect) {
-      HTTP.get('/case-insensitive-method-3', expect(function (err, res) {
-        test.equal(err, null);
-        test.equal(res.data, true);
-      }));
-    },
-  ]);
+  Tinytest.addAsync('JSON Routes - support case-insensitive HTTP method types - Method 3', async function (test) {
+    try {
+      const response = await fetch('/case-insensitive-method-3');
+      const data = await response.json();
+      test.equal(data, true);
+    } catch (err) {
+      test.fail('Fetch failed: ' + err);
+    }
+  });
+
 }

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -2,14 +2,14 @@
 
 var express = Npm.require('express');
 var bodyParser = Npm.require('body-parser');
-var { queryParser } = Npm.require('express-query-parser');
+var query = Npm.require('connect-query');
 
 JsonRoutes = {};
 
 // Override default request size
 WebApp.handlers.use(bodyParser.urlencoded({ limit: '50mb', extended: false }));
 WebApp.handlers.use(bodyParser.json({ limit: '50mb' }));
-WebApp.handlers.use(queryParser());
+WebApp.handlers.use(query());
 
 // Handler for adding middleware before an endpoint.
 // Also serves as a namespace for middleware packages to declare their middleware functions.

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -1,33 +1,29 @@
 /* global JsonRoutes:true */
 
-var Fiber = Npm.require('fibers');
-var connect = Npm.require('connect');
-var connectRoute = Npm.require('connect-route');
+var express = Npm.require('express');
 var bodyParser = Npm.require('body-parser');
-var query = Npm.require('connect-query');
+var { queryParser } = Npm.require('express-query-parser');
 
 JsonRoutes = {};
 
-WebApp.connectHandlers.use(bodyParser.urlencoded({limit: '50mb', extended: false})); //Override default request size
-WebApp.connectHandlers.use(bodyParser.json({limit: '50mb'})); //Override default request size
-WebApp.connectHandlers.use(query());
+// Override default request size
+WebApp.handlers.use(bodyParser.urlencoded({ limit: '50mb', extended: false }));
+WebApp.handlers.use(bodyParser.json({ limit: '50mb' }));
+WebApp.handlers.use(queryParser());
 
-// Handler for adding middleware before an endpoint (JsonRoutes.middleWare
-// is just for legacy reasons). Also serves as a namespace for middleware
-// packages to declare their middleware functions.
-JsonRoutes.Middleware = JsonRoutes.middleWare = connect();
-WebApp.connectHandlers.use(JsonRoutes.Middleware);
+// Handler for adding middleware before an endpoint.
+// Also serves as a namespace for middleware packages to declare their middleware functions.
+JsonRoutes.Middleware = express();
+WebApp.handlers.use(JsonRoutes.Middleware);
 
 // List of all defined JSON API endpoints
 JsonRoutes.routes = [];
 
 // Save reference to router for later
-var connectRouter;
+var expressRouter = express.Router();
 
 // Register as a middleware
-WebApp.connectHandlers.use(Meteor.bindEnvironment(connectRoute(function (router) {
-  connectRouter = router;
-})));
+WebApp.handlers.use(expressRouter);
 
 // Error middleware must be added last, to catch errors from prior middleware.
 // That's why we cache them and then add after startup.
@@ -42,17 +38,17 @@ Meteor.startup(function () {
   _.each(errorMiddlewares, function (errorMiddleware) {
     errorMiddleware = _.map(errorMiddleware, function (maybeFn) {
       if (_.isFunction(maybeFn)) {
-        // A connect error middleware needs exactly 4 arguments because they use fn.length === 4 to
+        // Express error middleware needs exactly 4 arguments because they use fn.length === 4 to
         // decide if something is an error middleware.
-        return function (a, b, c, d) {
-          Meteor.bindEnvironment(maybeFn)(a, b, c, d);
+        return function (err, req, res, next) {
+          maybeFn(err, req, res, next);
         }
       }
 
       return maybeFn;
     });
 
-    WebApp.connectHandlers.use.apply(WebApp.connectHandlers, errorMiddleware);
+    WebApp.handlers.use.apply(WebApp.handlers, errorMiddleware);
   });
 
   errorMiddlewares = [];
@@ -70,16 +66,14 @@ JsonRoutes.add = function (method, path, handler) {
     path: path,
   });
 
-  connectRouter[method.toLowerCase()](path, function (req, res, next) {
+  expressRouter[method.toLowerCase()](path, async function (req, res, next) {
     // Set headers on response
     setHeaders(res, responseHeaders);
-    Fiber(function () {
-      try {
-        handler(req, res, next);
-      } catch (error) {
-        next(error);
-      }
-    }).run();
+    try {
+      await handler(req, res, next);
+    } catch (error) {
+      next(error);
+    }
   });
 };
 

--- a/packages/json-routes/package.js
+++ b/packages/json-routes/package.js
@@ -16,7 +16,7 @@ Package.describe({
 Npm.depends({
   express: '4.18.2',
   'body-parser': '1.20.2',
-  'express-query-parser': '1.3.3',
+  'connect-query': '1.0.0',
 });
 
 Package.onUse(function (api) {

--- a/packages/json-routes/package.js
+++ b/packages/json-routes/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'simple:json-routes',
-  version: '2.3.1',
+  version: '3.0.0',
 
   // Brief, one-line summary of the package.
   summary: 'The simplest way to define server-side routes that return JSON',
@@ -14,14 +14,13 @@ Package.describe({
 });
 
 Npm.depends({
-  connect: '3.7.0',
-  'connect-route': '0.1.5',
-  'body-parser': '1.19.0',
-  'connect-query': '1.0.0',
+  express: '4.18.2',
+  'body-parser': '1.20.2',
+  'express-query-parser': '1.3.3',
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('2.4');
+  api.versionsFrom('3.0-beta.0');
 
   api.use([
     'underscore',
@@ -43,6 +42,6 @@ Package.onTest(function (api) {
   api.use('tinytest');
   api.use('test-helpers');
   api.use('simple:json-routes');
-  api.use('http');
+  api.use('fetch');
   api.addFiles('json-routes-tests.js');
 });

--- a/packages/rest-json-error-handler/README.md
+++ b/packages/rest-json-error-handler/README.md
@@ -1,13 +1,13 @@
 # Compatibility
 
-**Compatible with Meteor 2.4**
+**Compatible with Meteor 2.4 and Meteor 3.0**
 
 This repository provides versions for the package [simple:rest-json-error-handler](https://github.com/meteor-compat/meteor-rest/tree/devel/packages/rest-json-error-handler) that are compatible with latest Meteor. This is necessary because the author is not maintaining package anymore.
 
 ## Changes
 - v1.1.3
-  - Update simple:json-routes to 3.0.0
-  - - `api.versionsFrom` on `Package.onUse` includes `3.0`.
+  - Relaxed `simple:json-routes` dependency to include `v3.0.0`.
+  - `api.versionsFrom` on `Package.onUse` includes Meteor version `3.0`.
 - v1.1.1
   - Update simple:json-routes to 2.3.0
 - v1.1.0

--- a/packages/rest-json-error-handler/README.md
+++ b/packages/rest-json-error-handler/README.md
@@ -5,6 +5,9 @@
 This repository provides versions for the package [simple:rest-json-error-handler](https://github.com/meteor-compat/meteor-rest/tree/devel/packages/rest-json-error-handler) that are compatible with latest Meteor. This is necessary because the author is not maintaining package anymore.
 
 ## Changes
+- v1.1.3
+  - Update simple:json-routes to 3.0.0
+  - - `api.versionsFrom` on `Package.onUse` includes `3.0`.
 - v1.1.1
   - Update simple:json-routes to 2.3.0
 - v1.1.0

--- a/packages/rest-json-error-handler/package.js
+++ b/packages/rest-json-error-handler/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'simple:rest-json-error-handler',
-  version: '1.1.1',
+  version: '1.1.3',
 
   // Brief, one-line summary of the package.
   summary: 'middleware for handling standard Connect errors',
@@ -14,15 +14,15 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('2.4');
-  api.use('simple:json-routes@2.3.0');
+  api.versionsFrom(['2.4', '3.0-beta.0']);
+  api.use('simple:json-routes@2.3.0||3.0.0');
   api.addFiles('json_error_handler.js', 'server');
 });
 
 Package.onTest(function (api) {
   api.use([
     'http',
-    'simple:json-routes@2.3.0',
+    'simple:json-routes@2.3.0||3.0.0',
     'simple:rest-json-error-handler',
     'test-helpers',
     'tinytest',


### PR DESCRIPTION
`json-routes@3.0.0`  
- Migrated to new `webapp` APIs available in [Meteor 3.0](https://github.com/meteor/meteor/blob/release-3.0/docs/generators/changelog/versions/3.0.md).
- Npm dependencies updated from `connect` to `express`.
- `Fibers` usage removed and replaced with `async`/`await`.
- Deprecated `http` package replaced with `fetch` in tests.
- Updated `README`.

`rest-json-error-handler`
- Relaxed `simple:json-routes` dependency to include v3.0.0.
- `api.versionsFrom` on `Package.onUse` includes Meteor version `3.0`.